### PR TITLE
Add ease of use and limitations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 meteor-autocompletion
 =====================
 
-`meteor-autocompletion` provides autocompletion to `<input>` fields in [MeteorJS](https://meteor.com). The package will search for the inputed text in a MeteorJS collection and return similar results. Results can be choosed using the arrow keys and enter or by clicking with the mouse.
+`meteor-autocompletion` provides simple, easy-to-use autocompletion to `<input>` fields in [MeteorJS](https://meteor.com). The package will search for the inputed text in a MeteorJS collection and return similar results. Results can be choosed using the arrow keys and enter or by clicking with the mouse.
 
 ![Autocompleting a name](https://raw.github.com/sebdah/meteor-autocompletion/master/docs/example.png)
 
@@ -83,6 +83,12 @@ The following configuration options can be sent to `AutoCompletion.autocomplete`
 You can enable debug output by adding the following to your `Template.template_name.rendered` function:
 
     AutoCompletion.enableLogging = true;
+
+Current limitation
+------------------
+* Only one collection can be searched. For searching in multiple collections, see the [autocomplete](https://atmosphere.meteor.com/package/autocomplete) package
+* searching is done only in one field of the collection
+* search results are simply the values of matching fields. For customized search results using a template ([example](http://twitter.github.io/typeahead.js/examples/), see the [typeahead](https://atmosphere.meteor.com/package/typeahead) package.
 
 Author
 ------


### PR DESCRIPTION
Please republish the package so users can choose between simple straightforward autocomplete and more involved options like typeahead. Thank!
